### PR TITLE
Remove left-over debug statement

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,9 +20,6 @@
     # TODO it would be nice to have a verified hash here
   register: qFlipper_download
 
-- debug:
-    msg: "{{ qFlipper_download }}"
-
 - name: Set up symlink for qFipper
   ansible.builtin.file:
     state: link


### PR DESCRIPTION
This statement did not impede the function of the role, but we also do not need it anymore.