### PR TITLE
:sparkles: Download release meta-data from qFlipper to always obtain the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,31 @@ a Desktop environment.
 
 ### Configuration
 
-Please note that all variables have default values and usually do not need to be changed.
+The defaults are usually suitable for installation. Feel free to change them if they do not fit your needs.
 
-* `flipper_zero_qFlipper_download`: URL to the qFlipper AppImage
-* `flipper_zero_qFlipper_sha256`: SHA256 checksum of the AppImage file
+
+Controlling the files on the target system:
+
 * `flipper_zero_qFlipper_target`: Path where the AppImage will be stored
 * `flipper_zero_qFlipper_symlink`: Path to a symlink for version-independent access
 * `flipper_zero_udev_name`: How to name the udev rule. (Modify if you want to change the priority.)
+
+
+For automatic download:
+
+* `flipper_zero_qFlipper_release`: release type, currently available are `release`, `release-candidate` and `development` (defaults to `release`)
+* `flipper_zero_qFlipper_platform`: target platform, currently available are `windows/amd64`, `macos/amd64` and `linux//amd64` (defaults to `linux/amd64`)
+* `flipper_zero_qFlipper_meta_url`: URL to the release meta-data
+
+
+To fix the release, set:
+
+* `flipper_zero_qFlipper_download`: URL to the qFlipper AppImage
+* `flipper_zero_qFlipper_sha256`: SHA256 checksum of the AppImage file (optional, checks omitted if not defined)
+
+
+Please note that this role is not suited for windows. Although the architecture `windows/amd64` and be provided, there are two different packages in the stream and the first one would be selected.
+
 
 ### Requirements
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,16 @@
 # Default configuration for Flipper Zero
 ---
-flipper_zero_qFlipper_download: "https://update.flipperzero.one/builds/qFlipper/1.1.3/qFlipper-x86_64-1.1.3.AppImage"
-flipper_zero_qFlipper_sha256: "53134ba064d9c99cd2cf2882e9cd13a34be3acfb29a6e03bbacec3ec1a815693"
 flipper_zero_qFlipper_target: "/usr/local/bin/"
 flipper_zero_qFlipper_symlink: "/usr/local/bin/qFlipper"
 flipper_zero_udev_name: "42-flipperzero.rules"
+
+# Options for download of latest release
+flipper_zero_qFlipper_meta_url: "https://update.flipperzero.one/qFlipper/directory.json"
+flipper_zero_qFlipper_release: "release"
+flipper_zero_qFlipper_platform: "linux/amd64"
+
+# Set a direct URL if you want to pin the version
+# flipper_zero_qFlipper_download: "https://update.flipperzero.one/builds/qFlipper/1.1.3/qFlipper-x86_64-1.1.3.AppImage"
+
+# The hash is optional, if not provided, checking will be omitted
+# flipper_zero_qFlipper_sha256: "53134ba064d9c99cd2cf2882e9cd13a34be3acfb29a6e03bbacec3ec1a815693"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,50 @@
 # Tasks for Flipper Zero
 ---
+
+- name: Retrieve latest release from web
+  block:
+    - tempfile:
+        state:  file
+        suffix: "qflipper-release"
+      register: temp_release
+      changed_when: false
+
+    - name: Get Release meta-data
+      ansible.builtin.get_url:
+        url: "{{ flipper_zero_qFlipper_meta_url }}"
+        dest: "{{ temp_release.path }}"
+        owner: root
+        group: root
+        mode: '0644'
+      changed_when: false
+
+    - name: Parse Release JSON
+      ansible.builtin.set_fact:
+        qflipper_releases: "{{ lookup('file', temp_release.path) | from_json  }}"
+
+    - ansible.builtin.set_fact:
+        version_query: "channels[?id == '{{ flipper_zero_qFlipper_release }}'].versions[0]"
+
+    - ansible.builtin.set_fact:
+        file_query: "files[?target == '{{ flipper_zero_qFlipper_platform }}']"
+
+    - name: Extract meta-data
+      ansible.builtin.set_fact:
+        qflipper_version: "{{ qflipper_releases | json_query(version_query)  | first }}"
+
+    - name: Get target
+      ansible.builtin.set_fact:
+        qflipper_target: "{{ qflipper_version | json_query(file_query) | first }}"
+
+    - name: Set facts for download
+      ansible.builtin.set_fact:
+        flipper_zero_qFlipper_download: "{{ qflipper_target.url }}"
+        flipper_zero_qFlipper_sha256: "{{ qflipper_target.sha256 }}"
+
+  # Only run block when variables were not defined manually
+  when: flipper_zero_qFlipper_download is not defined
+
+
 - name: Make sure udev rules are in place
   ansible.builtin.copy:
     src: "files/flipperzero.rules"
@@ -9,16 +54,23 @@
     mode: '0644'
   notify: reload udev
 
+
+- name: Prepare checksum if available
+  ansible.builtin.set_fact:
+    sha256: "sha256:{{ flipper_zero_qFlipper_sha256 }}"
+  when: flipper_zero_qFlipper_sha256 is defined
+
 - name: Download qFlipper
   ansible.builtin.get_url:
     url: "{{ flipper_zero_qFlipper_download }}"
     dest: "{{ flipper_zero_qFlipper_target }}"
-    checksum: "sha256:{{ flipper_zero_qFlipper_sha256 }}"
+    checksum: "{{ sha256 | default('') }}"
     force: no
     owner: root
     group: root
     mode: "0755"
   register: qFlipper_download
+
 
 - name: Set up symlink for qFlipper
   ansible.builtin.file:


### PR DESCRIPTION
Instead of specifying a fixed release, download the meta-data from https://update.flipperzero.one/qFlipper/directory.json and chose the latest stable release. 

Target release and platform can be configured.

Pinning a specific release is still available.